### PR TITLE
fix: ptp deadlock on send

### DIFF
--- a/include/libvdeplug.h
+++ b/include/libvdeplug.h
@@ -65,6 +65,8 @@ int vde_ctlfd(VDECONN *conn);
 
 int vde_close(VDECONN *conn);
 
+int vde_pollhup_handler(VDECONN *conn);
+
 /* vdestream */
 
 struct vdestream;

--- a/include/libvdeplug_mod.h
+++ b/include/libvdeplug_mod.h
@@ -24,7 +24,7 @@ struct vdeplug_module {
 	int (* vde_datafd)(VDECONN *conn);
 	int (* vde_ctlfd)(VDECONN *conn);
 	int (* vde_close)(VDECONN *conn);
-  int (* vde_pollhup_handler)(VDECONN *conn);
+	int (* vde_pollhup_handler)(VDECONN *conn);
 };
 
 struct vdeparms {

--- a/include/libvdeplug_mod.h
+++ b/include/libvdeplug_mod.h
@@ -24,6 +24,7 @@ struct vdeplug_module {
 	int (* vde_datafd)(VDECONN *conn);
 	int (* vde_ctlfd)(VDECONN *conn);
 	int (* vde_close)(VDECONN *conn);
+  int (* vde_pollhup_handler)(VDECONN *conn);
 };
 
 struct vdeparms {

--- a/libvdeplug4/libvdeplug.c
+++ b/libvdeplug4/libvdeplug.c
@@ -269,3 +269,18 @@ int vde_close(VDECONN *conn)
 		return -1;
 	}
 }
+
+int vde_pollhup_handler(VDECONN *conn) {
+	if (__builtin_expect(conn!=0,1)) {
+		void *handle=conn->handle;
+		/* vde_close frees the struct conn */
+		int rv=conn->module->vde_pollhup_handler(conn);
+		if (rv < 0 ) 
+      return vde_close(conn);
+
+		return rv;
+	} else {
+		errno=EBADF;
+		return -1;
+	}
+}

--- a/libvdeplug4/libvdeplug.c
+++ b/libvdeplug4/libvdeplug.c
@@ -276,7 +276,7 @@ int vde_pollhup_handler(VDECONN *conn) {
 		/* vde_close frees the struct conn */
 		int rv=conn->module->vde_pollhup_handler(conn);
 		if (rv < 0 ) 
-      return vde_close(conn);
+			return vde_close(conn);
 
 		return rv;
 	} else {

--- a/libvdeplug4/libvdeplug_ptp.c
+++ b/libvdeplug4/libvdeplug_ptp.c
@@ -258,20 +258,20 @@ static ssize_t vde_ptp_send(VDECONN *conn,const void *buf,size_t len,int flags)
 	struct vde_ptp_conn *vde_conn = (struct vde_ptp_conn *)conn;
 #ifdef CONNECTED_P2P
 	ssize_t retval;
-	if (__builtin_expect(((retval=send(vde_conn->fddata,buf,len,0)) >= 0),1))
+	if (__builtin_expect(((retval=send(vde_conn->fddata,buf,len,MSG_DONTWAIT)) >= 0),1))
 		return retval;
 	else {
-		if (__builtin_expect(errno == ENOTCONN || errno == EDESTADDRREQ,0)) {
+		if (__builtin_expect(errno == ENOTCONN || errno == EDESTADDRREQ,MSG_DONTWAIT)) {
 			if (__builtin_expect(vde_conn->outsock != NULL,1)) {
 				connect(vde_conn->fddata, vde_conn->outsock,vde_conn->outlen);
-				return send(vde_conn->fddata,buf,len,0);
+				return send(vde_conn->fddata,buf,len,MSG_DONTWAIT);
 			} else
 				return retval;
 		} else
 			return retval;
 	}
 #else
-	return sendto(vde_conn->fddata,buf,len,0, vde_conn->outsock,vde_conn->outlen);
+	return sendto(vde_conn->fddata,buf,len,MSG_DONTWAIT, vde_conn->outsock,vde_conn->outlen);
 #endif
 }
 

--- a/srcvdeplug4/vde_plug.c
+++ b/srcvdeplug4/vde_plug.c
@@ -133,12 +133,12 @@ int plug2stream(void) {
 						pollv[2].revents & POLLIN),0))
 			break;
 
-    if (pollv[1].revents & (POLLHUP | POLLNVAL)) {
-      if (vde_pollhup_handler(conn) < 0) {
-        break;
-      } 
-      continue;
-    }
+		if (pollv[1].revents & (POLLHUP | POLLNVAL)) {
+			if (vde_pollhup_handler(conn) < 0) {
+				break;
+			} 
+			continue;
+		}
 		if (pollv[0].revents & POLLIN) {
 			nx = read(STDIN_FILENO,bufin,sizeof(bufin));
 			/* if POLLIN but not data it means that the stream has been
@@ -205,19 +205,19 @@ int plug2plug(void)
 				(pollv[2].revents | pollv[3].revents) & POLLIN)
 			break;
 
-    if (pollv[0].revents & (POLLHUP | POLLNVAL)) {
-      if (vde_pollhup_handler(conn) < 0) {
-        break;
-      } 
-      continue;
-    }
+		if (pollv[0].revents & (POLLHUP | POLLNVAL)) {
+			if (vde_pollhup_handler(conn) < 0) {
+				break;
+			} 
+			continue;
+		}
 
-    if (pollv[1].revents & (POLLHUP | POLLNVAL)) {
-      if (vde_pollhup_handler(conn2) < 0) {
-        break;
-      } 
-      continue;
-    }
+		if (pollv[1].revents & (POLLHUP | POLLNVAL)) {
+			if (vde_pollhup_handler(conn2) < 0) {
+				break;
+			} 
+			continue;
+		}
 
 		if (pollv[0].revents & POLLIN) {
 			nx = vde_recv(conn, bufin, VDE_ETHBUFSIZE,0);


### PR DESCRIPTION
I have noticed that if you connect two `vdens` using the `ptp` plugin, the basic functionalities of the network would work (es. ping), but as soon as you start iperf3 the connection would stop working.
I have observed that if you use the `--bidir` flag on iperf3 and your system is under stress (maybe using stress-ng) the bug is more easily reproducible.

I have found that the bug was in the `ptp` plugin. In particular there is very specific case in which both ends of the connection would write to the socket used for the connection, but the socket is full (unix sockets on Linux have a max capacity, on my system is around 95000 bytes). This would cause a deadlock as both `send` would block.

I fixed this by adding the `MSG_DONTWAIT` flag that enables nonblocking operation.

Let me know if this makes sens.